### PR TITLE
pod-checkpointer: use HOST_IP to query kubelet API

### DIFF
--- a/pkg/checkpoint/kubelet.go
+++ b/pkg/checkpoint/kubelet.go
@@ -2,6 +2,7 @@ package checkpoint
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/golang/glog"
@@ -12,7 +13,7 @@ import (
 )
 
 // A minimal kubelet client. It assumes the kubelet can be reached the kubelet's insecure API at
-// 127.0.0.1:10255 and the secure API at 127.0.0.1:10250.
+// HOST_IP:10255 and the secure API at HOST_IP:10250 or localhost at the same ports.
 type kubeletClient struct {
 	insecureClient *rest.RESTClient
 	secureClient   *rest.RESTClient
@@ -28,12 +29,18 @@ func newKubeletClient(config *rest.Config) (*kubeletClient, error) {
 	config.TLSClientConfig.CAFile = ""
 	config.TLSClientConfig.CAData = nil
 
+	hostIP := os.Getenv("HOST_IP")
+	// Default to previous behaviour of using localhost.
+	if hostIP == "" {
+		hostIP = "127.0.0.1"
+	}
+
 	// Shallow copy.
 	insecureConfig := *config
 	secureConfig := *config
 
-	insecureConfig.Host = "http://127.0.0.1:10255"
-	secureConfig.Host = "https://127.0.0.1:10250"
+	insecureConfig.Host = fmt.Sprintf("http://%s:10255", hostIP)
+	secureConfig.Host = fmt.Sprintf("https://%s:10250", hostIP)
 
 	client := new(kubeletClient)
 	var err error


### PR DESCRIPTION
- Pod-checkpointer logs errors that it
  can't talk to the kubelet API on secure/insecure ports.

  The reason is that the query is made to the urls:
    - https://127.0.0.1:10250/pods or
    - http://127.0.0.1:12055/pods

  This works fine if the kubelet is running as a service on the host but
  results in errors where kubelet runs as a pod.

  To fix the problem we use the `status.hostIP` from pod spec exposed as
  a environment variable under `HOST_IP`.

  If the `HOST_IP` environment variable is not present we  fallback on
  the previous method at localhost.

Signed-off-by: Imran Pochi <imran@kinvolk.io>