### PR TITLE
pkg/helm: set wait to true

### DIFF
--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -19,6 +19,11 @@ const (
 	defaultHelmStorageDriver = "secrets"
 )
 
+type installError struct {
+	err   error
+	chart chartInfo
+}
+
 // InstallCharts installs all the helm charts in the given charts directory.
 func InstallCharts(kubeconfigPath string, config clientcmd.ClientConfig, chartsDir string) error {
 	// check if charts directory exists
@@ -36,16 +41,33 @@ func InstallCharts(kubeconfigPath string, config clientcmd.ClientConfig, chartsD
 	if err != nil {
 		return fmt.Errorf("getting charts from charts directory %q: %v", chartsDir, err)
 	}
+
+	errors := make(chan installError, len(charts))
+
 	// iterate over all the namespaces found in the charts directory
 	for _, chart := range charts {
-		chartPath := filepath.Join(chartsDir, chart.namespace, chart.name)
-		// install charts found in each namespace directory
-		if err := installChart(kubeconfigPath, chart.namespace, chart.name, chartPath); err != nil {
-			return err
+		go func(chart chartInfo) {
+			chartPath := filepath.Join(chartsDir, chart.namespace, chart.name)
+			// install charts found in each namespace directory
+			errors <- installError{
+				err:   installChart(kubeconfigPath, chart.namespace, chart.name, chartPath),
+				chart: chart,
+			}
+		}(chart)
+	}
+
+	err = nil
+
+	for range charts {
+		i := <-errors
+		if i.err != nil {
+			util.UserOutput(fmt.Sprintf("Installing chart %q in namespace %q failed: %v", i.chart.name, i.chart.namespace, i.err))
+
+			err = fmt.Errorf("installing charts failed")
 		}
 	}
 
-	return nil
+	return err
 }
 
 // installChart is a helper function to install a single helm chart

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -89,6 +89,7 @@ func installChart(kubeconfigPath, namespace, chartName, chartPath string) error 
 	install.ReleaseName = chartName
 	install.Namespace = namespace
 	install.CreateNamespace = true
+	install.Wait = true
 	release, err := install.Run(chart, values)
 	if err != nil {
 		return err

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -32,18 +32,16 @@ func InstallCharts(kubeconfigPath string, config clientcmd.ClientConfig, chartsD
 		return nil
 	}
 	// get all the charts
-	namespaceChartsMap, err := getCharts(chartsDir)
+	charts, err := getCharts(chartsDir)
 	if err != nil {
 		return fmt.Errorf("getting charts from charts directory %q: %v", chartsDir, err)
 	}
 	// iterate over all the namespaces found in the charts directory
-	for namespace, charts := range namespaceChartsMap {
-		for _, chartName := range charts {
-			chartPath := filepath.Join(chartsDir, namespace, chartName)
-			// install charts found in each namespace directory
-			if err := installChart(kubeconfigPath, namespace, chartName, chartPath); err != nil {
-				return err
-			}
+	for _, chart := range charts {
+		chartPath := filepath.Join(chartsDir, chart.namespace, chart.name)
+		// install charts found in each namespace directory
+		if err := installChart(kubeconfigPath, chart.namespace, chart.name, chartPath); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/helm/util.go
+++ b/pkg/helm/util.go
@@ -10,26 +10,34 @@ import (
 	"github.com/kubernetes-sigs/bootkube/pkg/util"
 )
 
+type chartInfo struct {
+	name      string
+	namespace string
+}
+
 // getCharts returns the map structure of charts found in sub directories
 // Sub directories of chartsDir corresponds to the namespaces the charts are to be installed.
 // Each namespace sub directory contains the respectie charts.
 // This method returns the map structure of namespace directory name as key and path of the charts as values.
-func getCharts(chartsDir string) (map[string][]string, error) {
-	var charts = map[string][]string{}
-	dirs, err := getDirs(chartsDir)
+func getCharts(chartsDir string) ([]chartInfo, error) {
+	charts := []chartInfo{}
+	namespaces, err := getDirs(chartsDir)
 	if err != nil {
 		return nil, err
 	}
 
-	for _, dir := range dirs {
-		chartsInDir := []string{}
-		path := filepath.Join(chartsDir, dir)
-		ch, err := getDirs(path)
+	for _, namespace := range namespaces {
+		ch, err := getDirs(filepath.Join(chartsDir, namespace))
 		if err != nil {
 			return nil, err
 		}
-		chartsInDir = append(chartsInDir, ch...)
-		charts[dir] = chartsInDir
+
+		for _, c := range ch {
+			charts = append(charts, chartInfo{
+				namespace: namespace,
+				name:      c,
+			})
+		}
 	}
 
 	return charts, nil

--- a/pkg/helm/util_test.go
+++ b/pkg/helm/util_test.go
@@ -64,22 +64,19 @@ func TestGetCharts(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if len(namespaceDirs) != len(namespaceChartsMap) {
+	if len(chartDirs) != len(namespaceChartsMap) {
 		t.Fatal("number of directories did not match")
 	}
 
-	for namespace, charts := range namespaceChartsMap {
-		path := filepath.Join(chartsDir, namespace)
+	for _, chart := range namespaceChartsMap {
+		path := filepath.Join(chartsDir, chart.namespace)
 		if !isPresent(path, namespaceDirs) {
-			t.Fatalf("did not find namespace directory named `%s`", namespace)
+			t.Fatalf("did not find namespace directory named %q", chart.namespace)
 		}
 
-		for _, chart := range charts {
-			path = filepath.Join(chartsDir, namespace, chart)
-			if !isPresent(path, chartDirs) {
-				t.Fatalf("chart `%s` not found", chart)
-			}
-
+		path = filepath.Join(chartsDir, chart.namespace, chart.name)
+		if !isPresent(path, chartDirs) {
+			t.Fatalf("chart %q not found", chart.name)
 		}
 	}
 }


### PR DESCRIPTION
So when installing the chart, bootkube will wait for the chart to
converge before returning. This is to ensure, that everything has been
deployed correctly.

Closes #8

This is currently problematic, as in Lokomotive case, the Calico charts gets installed before Kubernetes chart, so Calico chart never converges, as the nodes are not able to join the cluster as Kubernetes chart is missing. The potential solution for that would be to e.g. install the charts in parallel.

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>