### PR TITLE
pkg/helm: fix Helm logger formatting

### DIFF
--- a/pkg/helm/util.go
+++ b/pkg/helm/util.go
@@ -82,6 +82,6 @@ func loadValuesFile(path string) (map[string]interface{}, error) {
 // of a given format.
 func log(namespace, chartName string) func(format string, a ...interface{}) {
 	return func(format string, a ...interface{}) {
-		util.UserOutput(fmt.Sprintf("%s/%s: %s\n", namespace, chartName, format), a)
+		util.UserOutput(fmt.Sprintf("%s/%s: %s\n", namespace, chartName, format), a...)
 	}
 }


### PR DESCRIPTION
Regression introduced in d290a286063384fb247a5a8053cd9a45e7b20425, where
log helper function did not properly expand given arguments, which
resulted in passing them to util.UserOutput function as a slice instead
of as separate arguments, which caused log messages to be formatted
incorrectly.

This commit fixes it and adds unit test to verify expected behavior.

Closes #14

Signed-off-by: Mateusz Gozdek <mateusz@kinvolk.io>