### PR TITLE
Make bootkube report Helm installation errors faster and respect global asset timeout

### DIFF
--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -75,7 +75,7 @@ func (b *bootkube) Run() error {
 	kubeconfigPath := filepath.Join(b.assetDir, asset.AssetPathAdminKubeConfig)
 	chartsPath := filepath.Join(b.assetDir, asset.AssetPathCharts)
 
-	if err = helm.InstallCharts(kubeconfigPath, chartsPath); err != nil {
+	if err = helm.InstallCharts(kubeconfigPath, chartsPath, assetTimeout); err != nil {
 		return err
 	}
 

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -75,7 +75,7 @@ func (b *bootkube) Run() error {
 	kubeconfigPath := filepath.Join(b.assetDir, asset.AssetPathAdminKubeConfig)
 	chartsPath := filepath.Join(b.assetDir, asset.AssetPathCharts)
 
-	if err = helm.InstallCharts(kubeconfigPath, kubeConfig, chartsPath); err != nil {
+	if err = helm.InstallCharts(kubeconfigPath, chartsPath); err != nil {
 		return err
 	}
 

--- a/pkg/bootkube/bootkube.go
+++ b/pkg/bootkube/bootkube.go
@@ -73,7 +73,9 @@ func (b *bootkube) Run() error {
 	}
 
 	kubeconfigPath := filepath.Join(b.assetDir, asset.AssetPathAdminKubeConfig)
-	if err = helm.InstallCharts(kubeconfigPath, kubeConfig, filepath.Join(b.assetDir, asset.AssetPathCharts)); err != nil {
+	chartsPath := filepath.Join(b.assetDir, asset.AssetPathCharts)
+
+	if err = helm.InstallCharts(kubeconfigPath, kubeConfig, chartsPath); err != nil {
 		return err
 	}
 

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -10,7 +10,6 @@ import (
 	"helm.sh/helm/v3/pkg/chart/loader"
 	"helm.sh/helm/v3/pkg/downloader"
 	"helm.sh/helm/v3/pkg/kube"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/kubernetes-sigs/bootkube/pkg/util"
 )
@@ -25,7 +24,7 @@ type installError struct {
 }
 
 // InstallCharts installs all the helm charts in the given charts directory.
-func InstallCharts(kubeconfigPath string, config clientcmd.ClientConfig, chartsDir string) error {
+func InstallCharts(kubeconfigPath string, chartsDir string) error {
 	// check if charts directory exists
 	present, err := isExists(chartsDir)
 	if err != nil {

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -56,18 +56,16 @@ func InstallCharts(kubeconfigPath string, chartsDir string, installTimeout time.
 		}(chart)
 	}
 
-	err = nil
-
 	for range charts {
 		i := <-errors
 		if i.err != nil {
 			util.UserOutput(fmt.Sprintf("Installing chart %q in namespace %q failed: %v", i.chart.name, i.chart.namespace, i.err))
 
-			err = fmt.Errorf("installing charts failed")
+			return fmt.Errorf("installing charts failed")
 		}
 	}
 
-	return err
+	return nil
 }
 
 // installChart is a helper function to install a single helm chart


### PR DESCRIPTION
Closes #16
Closes #18 